### PR TITLE
Fix incorrect installation prefix in rpm

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[install]
+prefix=/usr


### PR DESCRIPTION
When installed into fedora-34 template the application is placed into /usr/local instead of /usr directory of the template VM filesystem. As the result qubes based on the template do not have qubes-app installed.